### PR TITLE
metric export: add additional metadata, config and status fields associated with metrics

### DIFF
--- a/scripts/export/metric_export.py
+++ b/scripts/export/metric_export.py
@@ -36,6 +36,7 @@ def export_to_csv(workspace_id, metric_map, start_time):
     csv_file = f"{path}/{workspace_id}.csv"
     csv_columns = [
         "workspaceId",
+        "workspaceName",
         "metricName",
         "metricUuid",
         "metricId",
@@ -100,6 +101,7 @@ def main():
             metric_uuid = metric["metadata"]["uuid"]
             metric_map[metric_uuid] = {
                 "workspaceId": workspace_id,
+                "workspaceName": ws["name"],
                 "metricName": metric["metadata"]["name"],
                 "metricUuid": metric_uuid,
                 "metricId": metric["metadata"]["idSerial"],


### PR DESCRIPTION
This PR adds additional fields to the metric export to make it inline with the in product export implementation. Tested manually against a few clusters.